### PR TITLE
Mypyc demo

### DIFF
--- a/astropy/stats/funcs.py
+++ b/astropy/stats/funcs.py
@@ -19,6 +19,7 @@ from numpy.typing import ArrayLike, NDArray
 from astropy.utils.compat.optional_deps import HAS_BOTTLENECK, HAS_MPMATH, HAS_SCIPY
 
 from . import _stats
+from .mypyc_demo import histogram_intervals, interval_overlap_length
 
 __all__ = [
     "binned_binom_proportion",
@@ -1616,70 +1617,3 @@ def cdf_from_intervals(breaks: NDArray[float], totals: NDArray[float]) -> Callab
     c = np.concatenate(((0,), np.cumsum(totals * np.diff(b))))
     c /= c[-1]
     return lambda x: np.interp(x, b, c, 0, 1)
-
-
-def interval_overlap_length(i1: tuple[float, float], i2: tuple[float, float]) -> float:
-    """Compute the length of overlap of two intervals.
-
-    Parameters
-    ----------
-    i1, i2 : (float, float)
-        The two intervals, (interval 1, interval 2).
-
-    Returns
-    -------
-    l : float
-        The length of the overlap between the two intervals.
-
-    """
-    (a, b) = i1
-    (c, d) = i2
-    if a < c:
-        if b < c:
-            return 0.0
-        elif b < d:
-            return b - c
-        else:
-            return d - c
-    elif a < d:
-        if b < d:
-            return b - a
-        else:
-            return d - a
-    else:
-        return 0
-
-
-def histogram_intervals(
-    n: int, breaks: NDArray[float], totals: NDArray[float]
-) -> NDArray[float]:
-    """Histogram of a piecewise-constant weight function.
-
-    This function takes a piecewise-constant weight function and
-    computes the average weight in each histogram bin.
-
-    Parameters
-    ----------
-    n : int
-        The number of bins
-    breaks : (N,) array of float
-        Endpoints of the intervals in the PDF
-    totals : (N-1,) array of float
-        Probability densities in each bin
-
-    Returns
-    -------
-    h : array of float
-        The average weight for each bin
-
-    """
-    h = np.zeros(n)
-    start = breaks[0]
-    for i in range(len(totals)):
-        end = breaks[i + 1]
-        for j in range(n):
-            ol = interval_overlap_length((float(j) / n, float(j + 1) / n), (start, end))
-            h[j] += ol / (1.0 / n) * totals[i]
-        start = end
-
-    return h

--- a/astropy/stats/mypyc_demo.py
+++ b/astropy/stats/mypyc_demo.py
@@ -1,0 +1,63 @@
+from collections.abc import Iterable, Sequence
+
+import numpy as np
+from numpy.typing import NDArray
+
+
+def interval_overlap_length(i1: tuple[float, float], i2: tuple[float, float]) -> float:
+    """Compute the length of overlap of two intervals.
+
+    Parameters
+    ----------
+    i1, i2 : (float, float)
+        The two intervals, (interval 1, interval 2).
+
+    Returns
+    -------
+    l : float
+        The length of the overlap between the two intervals.
+
+    """
+    (a, b) = i1
+    (c, d) = i2
+    if a < c:
+        if b < c:
+            return 0.0
+        return b - c if b < d else d - c
+    if a < d:
+        return b - a if b < d else d - a
+    return 0.0
+
+
+def histogram_intervals(
+    n: int, breaks: Sequence[float], totals: Iterable[float]
+) -> NDArray[np.float64]:
+    """Histogram of a piecewise-constant weight function.
+
+    This function takes a piecewise-constant weight function and
+    computes the average weight in each histogram bin.
+
+    Parameters
+    ----------
+    n : int
+        The number of bins
+    breaks : (N,) array of float
+        Endpoints of the intervals in the PDF
+    totals : (N-1,) array of float
+        Probability densities in each bin
+
+    Returns
+    -------
+    h : array of float
+        The average weight for each bin
+
+    """
+    h = np.zeros(n)
+    start = breaks[0]
+    for i, tot in enumerate(totals):
+        end = breaks[i + 1]
+        for j in range(n):
+            h[j] += interval_overlap_length((j, j + 1), (n * start, n * end)) * tot
+        start = end
+
+    return h

--- a/astropy/stats/mypyc_demo.py
+++ b/astropy/stats/mypyc_demo.py
@@ -1,4 +1,4 @@
-from collections.abc import Iterable, Sequence
+from collections.abc import Sequence
 
 import numpy as np
 from numpy.typing import NDArray
@@ -23,14 +23,21 @@ def interval_overlap_length(i1: tuple[float, float], i2: tuple[float, float]) ->
     if a < c:
         if b < c:
             return 0.0
-        return b - c if b < d else d - c
-    if a < d:
-        return b - a if b < d else d - a
-    return 0.0
+        elif b < d:
+            return b - c
+        else:
+            return d - c
+    elif a < d:
+        if b < d:
+            return b - a
+        else:
+            return d - a
+    else:
+        return 0
 
 
 def histogram_intervals(
-    n: int, breaks: Sequence[float], totals: Iterable[float]
+    n: int, breaks: Sequence[float], totals: Sequence[float]
 ) -> NDArray[np.float64]:
     """Histogram of a piecewise-constant weight function.
 
@@ -54,10 +61,11 @@ def histogram_intervals(
     """
     h = np.zeros(n)
     start = breaks[0]
-    for i, tot in enumerate(totals):
+    for i in range(len(totals)):
         end = breaks[i + 1]
         for j in range(n):
-            h[j] += interval_overlap_length((j, j + 1), (n * start, n * end)) * tot
+            ol = interval_overlap_length((float(j) / n, float(j + 1) / n), (start, end))
+            h[j] += ol / (1.0 / n) * totals[i]
         start = end
 
     return h


### PR DESCRIPTION
I had a quick look at two functions in `astropy.stats.funcs`, both to see how much their implementation can be sped up in interpreted Python and how much they can be sped up by compiling with [Mypyc](https://mypyc.readthedocs.io/en/stable/introduction.html). I suspect similar speedups could be achieved elsewhere in `astropy.stats.funcs`, but I am not spending time investigating that right now because I think it is better to start a discussion before the coordination meeting ends.

The function argument values used for measuring performance are taken from the first and last parametrization of `astropy.stats.tests.test_funcs.test_histogram_intervals_known`.

EDIT: The first commit here updates function bodies, the second does not. The purpose of the second commit is to demonstrate that large speedups are possible without having to rewrite code (although rewriting annotations might be required). The first commit then demonstrates that small changes to the code can provide additional speedups.

#### Performance on current `main` (ae355d9bed2bdd1363396bd15b9575a34404cbc7)

```
$ ipython -i -c 'from astropy.stats import histogram_intervals'
Python 3.12.3 (main, Jun 18 2025, 17:59:45) [GCC 13.3.0]
Type 'copyright', 'credits' or 'license' for more information
IPython 9.2.0 -- An enhanced Interactive Python. Type '?' for help.
Tip: IPython supports combining unicode identifiers, eg F\vec<tab> will become F⃗, useful for physics equations. Play with \dot \ddot and others.

In [1]: %timeit histogram_intervals(4, (0, 1), (1,))
1.78 μs ± 3.3 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)

In [2]: %timeit histogram_intervals(3, (0, 0.5, 1), (1, 2))
2.54 μs ± 9.21 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
```

#### Performance with the first commit and interpreted Python

```
In [1]: %timeit histogram_intervals(4, (0, 1), (1,))
1.21 μs ± 3.34 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)

In [2]: %timeit histogram_intervals(3, (0, 0.5, 1), (1, 2))
2.17 μs ± 8.2 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
```

#### Performance with the first commit and compiled Python

```
In [1]: %timeit histogram_intervals(4, (0, 1), (1,))
731 ns ± 4.77 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)

In [2]: %timeit histogram_intervals(3, (0, 0.5, 1), (1, 2))
1.03 μs ± 3.61 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)
```

#### Performance with the second commit and compiled Python

```
In [1]: %timeit histogram_intervals(4, (0, 1), (1,))
851 ns ± 4.64 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)

In [2]: %timeit histogram_intervals(3, (0, 0.5, 1), (1, 2))
1.21 μs ± 5.41 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)
```

#### Compilation instructions

I installed Mypyc by running `pip install mypy` (not `pip install mypyc`).
```
$ mypyc --version
mypy 1.16.1 (compiled: yes)
```
To compile the code I simply ran `mypyc astropy/stats/mypyc_demo.py` which generated a C-extension in `build/` and also `astropy/stats/mypyc_demo.cpython-312-x86_64-linux-gnu.so` and `astropy/stats/mypyc_demo__mypyc.cpython-312-x86_64-linux-gnu.so`. Note that as long as those .so files are present Python will prefer them over `astropy/stats/mypyc_demo.py`. When you are done testing the compiled files it is best to delete them.

I am inviting here the people that were present in the `astropy` C-code replacement breakout yesterday: @nstarman, @eteq, @taldcroft, @astrofrog, @aragilar, @jehturner, @tepickering, @WilliamJamieson, @dhomeier

EDIT: I clearly remember @neutrinoceros being present too, but he's not listed among the attendees on the meeting notes.